### PR TITLE
migrate decode and encode to use Uint8Array

### DIFF
--- a/iconv-lite-umd.d.ts
+++ b/iconv-lite-umd.d.ts
@@ -8,7 +8,7 @@
 declare module "iconv-lite-umd" {
   // Basic API
   export function decode(
-    buffer: Buffer,
+    buffer: Uint8Array,
     encoding: string,
     options?: Options
   ): string;
@@ -17,7 +17,7 @@ declare module "iconv-lite-umd" {
     content: string,
     encoding: string,
     options?: Options
-  ): Buffer;
+  ): Uint8Array;
 
   export function encodingExists(encoding: string): boolean;
 


### PR DESCRIPTION
@bpasero, actually just looked and they use the same methods internally without any ceremony around. Sorry I didn't do it from the get go.